### PR TITLE
Fixes up test runs when there's no .env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,11 +10,24 @@
     }]
   ],
 
-  "presets": ["babel-preset-react-native-stage-0/decorator-support", "react-native-dotenv"],
+  "presets": ["babel-preset-react-native-stage-0/decorator-support"],
 
   "env": {
     "development": {
+      "presets": ["react-native-dotenv"],
       "plugins": [ "transform-react-jsx-source" ]
+    },
+    "test": {
+      "plugins": [
+        ["react-native-dotenv/babel-plugin-dotenv", {
+          "replacedModuleName": "react-native-dotenv",
+          "configDir": ".",
+          "filename": "env.sample"
+        }]
+      ]
+    },
+    "production": {
+      "presets": ["react-native-dotenv"]
     }
   }
 }

--- a/env.sample
+++ b/env.sample
@@ -1,4 +1,7 @@
+# This file is used as the .env file in tests
+#
+# Copy it to .env and replace with production information
 GRAPHQL_URL=http://localhost:3000/graphql
-GRAPHQL_API_KEY=
-MAPBOX_ACCESS_TOKEN=
+GRAPHQL_API_KEY=GRAPHQL_API_KEY
+MAPBOX_ACCESS_TOKEN=MAPBOX_ACCESS_TOKEN
 MAPBOX_STYLE_PATH=cityofboston/cj1p0mw1x000b2rmrocwwpyui

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "babel-preset-react-native-stage-0": "^1.0.1",
     "codecov": "^2.2.0",
     "del": "^3.0.0",
-    "dotenv": "^4.0.0",
+    "dotenv": "^2.0.0",
     "eslint": "^3",
     "eslint-config-prettier": "^2.1.1",
     "eslint-plugin-flowtype": "^2.34.0",
@@ -67,7 +67,7 @@
     "jest": "^20.0.4",
     "lint-staged": "^3.6.1",
     "prettier": "^1.4.4",
-    "react-native-dotenv": "^0.0.4",
+    "react-native-dotenv": "zetachang/react-native-dotenv",
     "react-test-renderer": "16.0.0-alpha.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1648,10 +1648,6 @@ dotenv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-2.0.0.tgz#bd759c357aaa70365e01c96b7b0bec08a6e0d949"
 
-dotenv@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
-
 duplexer2@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
@@ -4423,9 +4419,9 @@ react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz#32886242b3f2317e121f3aeb9b0a585e2b879b49"
 
-react-native-dotenv@^0.0.4:
+react-native-dotenv@zetachang/react-native-dotenv:
   version "0.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-dotenv/-/react-native-dotenv-0.0.4.tgz#cd66e8e5f227e0f8c9775004f158505fd60b7be0"
+  resolved "https://codeload.github.com/zetachang/react-native-dotenv/tar.gz/b455fdf6b3ace55e6816556ac3a158e1fc280382"
   dependencies:
     babel-plugin-dotenv "~0.0.2"
 


### PR DESCRIPTION
Switches to use GitHub verison of react-native-dotenv plugin, which has
support for the "filename" option.

Includes explicit downgrade to dotenv@^2.0.0 because that's what's
required by the babel-plugin-dotenv package, which is not explicitly
inculded because it's a subdirectory of the react-native-dotenv GitHub
repo.